### PR TITLE
Signed for j.ru

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Rafal Zawadzki, **jabberpl.org** (https://jabberpl.org)
 
 Thomas Camaran, **chatme.im** (https://chatme.im/)
 
+Oxpa, Ermine, **jabber.ru** (https://jabber.ru/)
 ...
 
 *	*	*


### PR DESCRIPTION
Better reverse order in sign lines: put server name to the front and then sort by the server name.
With more participants it will be difficult to maintain.