### PR TITLE
Clarify the registration limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fight spam:
   [XEP-0157: Contact Addresses for XMPP Services][XEP-0157] and
   react to incoming abuse reports in a timely fashion.
 
-* Limit the number of new user registrations per IP address and hour.
+* Limit the number of new user registrations per IP address per hour.
 
 * Monitor and review registrations from IP addresses with bad reputation
   (open proxy servers, Tor exit nodes), or enforce additional checks on


### PR DESCRIPTION
While initially reading the manifesto, I understood it as if the number
of registration should be limited per IP per hour, i.e. the only limit
is when you make too many registrations per hour from a particular IP,
then registrations from that IP get blocked for an hour.

However, I've seen someone else unrestand the previous wording
as if there were to be two separate limits, one per hour
regardless of IP, and one per IP for the entire server lifetime.

The latter doesn't make much sense.

This PR changes the wording so that it's more clear that it's about the
first meaning.